### PR TITLE
Added customizations for a EMCellMesh selector

### DIFF
--- a/example.ipynb
+++ b/example.ipynb
@@ -9,7 +9,9 @@
    "source": [
     "import obi_auth\n",
     "\n",
-    "from obi_notebook import get_entities, get_projects"
+    "from obi_notebook import get_entities, get_projects\n",
+    "\n",
+    "environment_str = \"staging\""
    ]
   },
   {
@@ -27,7 +29,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "token = obi_auth.get_token(environment=\"production\")"
+    "token = obi_auth.get_token(environment=environment_str)"
    ]
   },
   {
@@ -45,7 +47,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "project_context = get_projects.get_projects(token)"
+    "project_context = get_projects.get_projects(token, env=\"staging\")"
    ]
   },
   {
@@ -78,6 +80,7 @@
     "    default_scale=\"small\",\n",
     "    exclude_scales=[\"single\"],\n",
     "    add_columns=[\"subject.name\"],\n",
+    "    env=environment_str\n",
     ")"
    ]
   },
@@ -109,17 +112,50 @@
     "    project_context=project_context,\n",
     "    page_size=100,\n",
     "    add_columns=[\"mtypes\"],\n",
+    "    env=environment_str\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ab24b139",
+   "id": "2c9d28c4",
    "metadata": {},
    "outputs": [],
    "source": [
     "morph_ids"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90757b52",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cell_mesh_ids = []\n",
+    "circuit_ids = get_entities.get_entities(\n",
+    "    \"em-cell-mesh\",\n",
+    "    token,\n",
+    "    cell_mesh_ids,\n",
+    "    return_entities=False,\n",
+    "    multi_select=True,\n",
+    "    show_pages=True,\n",
+    "    project_context=project_context,\n",
+    "    page_size=10,\n",
+    "    env=environment_str,\n",
+    "    add_columns=['dense_reconstruction_cell_id', 'subject.name']\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6964ebe2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cell_mesh_ids"
    ]
   }
  ],


### PR DESCRIPTION
  - Translation from the end-point name to the entitysdk class now via a dict, since doing it via string transformation won't work. (Because both E and M are to be capitalized in EMCellMesh).
  - Added custom filters for EMCellMeshes: By the name of the underlying EMDenseReconstructionDataset and by cell id.
  - Display of the em cell ids was broken. To avoid that I now convert all columns of the DataFrame that is displayed to str before displaying it. I think this is unproblematic as it is purely for display. Nothing else is done on these data.