### PR TITLE
Use neutral info styling for successful grade submissions

### DIFF
--- a/src/obi_notebook/grading.py
+++ b/src/obi_notebook/grading.py
@@ -267,7 +267,7 @@ class GradeResult:
     def _repr_html_(self) -> str:
         """Render a styled result box for display in a notebook cell."""
         if self.ok:
-            color, background, icon = "#1a7f37", "#e9f7ec", "✓"
+            color, background, icon = "#175cd3", "#eff8ff", "✓"
         elif self.status_code == 400:
             color, background, icon = "#9a6700", "#fff8e1", "✎"
         else:
@@ -275,7 +275,7 @@ class GradeResult:
         headline = html.escape(self._headline())
         return (
             f'<div style="border-left:4px solid {color};background:{background};'
-            "padding:10px 14px;border-radius:4px;font-family:sans-serif;"
+            "margin:12px 0;padding:10px 14px;border-radius:4px;font-family:sans-serif;"
             f'color:{color};font-size:1.1em;">{icon} {headline}</div>'
         )
 


### PR DESCRIPTION
## Summary

The grade result box rendered by `GradeResult._repr_html_` was green for any successful submission, so a student scoring 0% saw a green box — easily read as a passing result. The passing threshold is configured in the third-party Moodle and unknown to this client, so no score-based color judgment (green/amber/red by score) can be made honestly.

- Successful submissions now render in a neutral informational blue (`#175cd3` on `#eff8ff`); the ✓ still signals that the submission went through, while the score speaks for itself.
- Error styling is unchanged: amber for shape-rejected answers (HTTP 400), red for grading/transport failures.
- Added `margin:12px 0` so the box no longer crowds the widgets above it.

| Case | Before | After |
|---|---|---|
| Success (any score) | green | neutral blue |
| HTTP 400 | amber | amber |
| Other errors | red | red |

## Testing

- `tox -e lint` passes (ruff format, ruff check, mypy).
- Rendered all four variants (0% success, 100% success, 400, transport error) to HTML and visually verified in a browser.